### PR TITLE
Modified docs to match the config argument of provider

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -162,7 +162,7 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 
 * `insecure` - (Optional) This is a switch to disable/enable https. (Default: `false`, means enable https).
 
-* `base_url` - (Optional) This is the base url.(Default: `https://api.ksyun.com`)
+* `domain` - (Optional) This is the base url of KSYUN API endpoint. (Default: `api.ksyun.com`) Setup to corresponding base URL if you are using private cloud or other delicated regions. 
 
 ## Testing
 


### PR DESCRIPTION
There is no `base_url` argument in KSYUN provider. This should be replaced with `domain`. 
This argument is important while using private cloud, dedicated regions and internal account. 